### PR TITLE
Update .jenkinstest

### DIFF
--- a/.jenkinstest
+++ b/.jenkinstest
@@ -10,6 +10,12 @@ pipeline {
       }
     }
     
+    stage("Env Variables") {
+        steps {
+            sh "printenv"
+        }
+    }
+    
     stage('Test') {
       steps {
         withGradle {


### PR DESCRIPTION
DO NOT MERGE - Showing all the environment variables. Appears GitHub credentials not being used for PR Coverage Reporting step, so seeing what env vars are there to possibly use for that,