### PR TITLE
Update .jenkinstest

### DIFF
--- a/.jenkinstest
+++ b/.jenkinstest
@@ -110,7 +110,7 @@ pipeline {
         when {
             allOf {
                 branch 'main' 
-                environment name: 'GIT_COMMIT_FED', value: 'true'
+                equals expected: 'true', actual: env.GIT_COMMIT_FED
             }
         }
         steps {
@@ -136,7 +136,7 @@ pipeline {
     
     stage('Test GIT_COMMIT_FED') {
         when {
-            environment name: 'GIT_COMMIT_FED', value: 'true'
+            equals expected: 'true', actual: env.GIT_COMMIT_FED
         }
         steps {
             echo "GIT_COMMIT_FED is ${GIT_COMMIT_FED}"


### PR DESCRIPTION
issue appears to be environment capturing GIT_COMMIT_FED inside when, scope issue. Using equals and env. instead