### PR TITLE
Update .jenkinstest

### DIFF
--- a/.jenkinstest
+++ b/.jenkinstest
@@ -109,7 +109,7 @@ pipeline {
         when {
             allOf {
                 branch 'main'
-                equals expected: 'true', actual: env.GIT_COMMIT_FED
+                equals expected: 'true', actual: GIT_COMMIT_FED
             }
         }
         steps {
@@ -135,7 +135,7 @@ pipeline {
     
     stage('Test GIT_COMMIT_FED') {
         when {
-            equals expected: 'true', actual: env.GIT_COMMIT_FED
+            equals expected: 'true', actual: GIT_COMMIT_FED
         }
         steps {
             echo "GIT_COMMIT_FED is ${GIT_COMMIT_FED}"


### PR DESCRIPTION
seeing if env. not needed in when tag even though environment tag seems to not pick up GIT_COMMIT_FED. A little confused about environment variable scopes in Jenkinsfile.